### PR TITLE
Use sufia-models as dev dependency

### DIFF
--- a/fedora-migrate.gemspec
+++ b/fedora-migrate.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "jettywrapper"
   spec.add_development_dependency "equivalent-xml"
-  spec.add_development_dependency "sufia", "~> 6.0.0.beta1"
+  spec.add_development_dependency "sufia-models", "~> 6.0.0.beta1"
 end


### PR DESCRIPTION
The full Sufia gem is unneccessary. Only the sufia-models gem is needed for testing migrations.