### PR TITLE
Add option to force relationship migration

### DIFF
--- a/lib/fedora_migrate/migration_options.rb
+++ b/lib/fedora_migrate/migration_options.rb
@@ -7,5 +7,13 @@ module FedoraMigrate
       self.conversions = options.nil? ? [] : [options[:convert]].flatten      
     end
 
+    def forced?
+      options[:force] || false
+    end
+
+    def not_forced?
+      !forced?
+    end
+
   end
 end

--- a/spec/unit/migration_options_spec.rb
+++ b/spec/unit/migration_options_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe FedoraMigrate::MigrationOptions do
+
+  class TestCase
+    include FedoraMigrate::MigrationOptions
+  end
+
+  describe "#conversion_options" do
+    subject do
+      TestCase.new.tap do |example|
+        example.options = { convert: 'datastream' }
+      end
+    end
+    specify "sets the name of the datastream to convert" do
+      expect(subject.conversion_options).to include "datastream"
+    end
+    it { is_expected.to be_not_forced }
+  end
+
+  describe "forced?" do
+    subject do
+      TestCase.new.tap do |example|
+        example.options = { convert: "datastream", force: true }
+      end
+    end
+    it { is_expected.to be_forced }
+  end
+
+  describe "forced?" do
+    subject do
+      TestCase.new.tap do |example|
+        example.options = { convert: "datastream", force: false }
+      end
+    end
+    it { is_expected.to be_not_forced }
+  end
+
+end

--- a/spec/unit/repository_migrator_spec.rb
+++ b/spec/unit/repository_migrator_spec.rb
@@ -14,6 +14,17 @@ describe FedoraMigrate::RepositoryMigrator do
     end
   end
 
+  context "when forcing" do
+    before do
+      allow_any_instance_of(FedoraMigrate::RepositoryMigrator).to receive(:source_objects).and_return([])
+      allow_any_instance_of(FedoraMigrate::RepositoryMigrator).to receive(:failed).and_return(1) 
+    end
+    subject { FedoraMigrate::RepositoryMigrator.new(namespace, { force: true }) }
+    specify "migrate relationships if failures are present" do
+      expect(subject.migrate_relationships).to be true
+    end
+  end
+
   context "without a given namespace" do
     describe "#namespace" do
       specify "is given in the repository profile" do


### PR DESCRIPTION
Even if any object fails to migrate, we can force the process to continue with migrating relationships.