### PR TITLE
Allow included application to create versions

### DIFF
--- a/lib/fedora_migrate/datastream_mover.rb
+++ b/lib/fedora_migrate/datastream_mover.rb
@@ -47,7 +47,7 @@ module FedoraMigrate
     def migrate_versions
       source.versions.each do |version|
         migrate_content(version)
-        target.create_version
+        target.create_version unless application_creates_versions?
         valid?(version)
       end
     end

--- a/lib/fedora_migrate/migration_options.rb
+++ b/lib/fedora_migrate/migration_options.rb
@@ -8,11 +8,21 @@ module FedoraMigrate
     end
 
     def forced?
-      options[:force] || false
+      option_true?(:force)
     end
 
     def not_forced?
       !forced?
+    end
+
+    def application_creates_versions?
+      option_true?(:application_creates_versions)
+    end
+    
+    private
+    
+    def option_true?(name)
+      !!(options && options[name])
     end
 
   end

--- a/lib/fedora_migrate/object_mover.rb
+++ b/lib/fedora_migrate/object_mover.rb
@@ -36,7 +36,7 @@ module FedoraMigrate
     def migrate_content_datastreams
       save
       target.attached_files.keys.each do |ds|
-        mover = FedoraMigrate::DatastreamMover.new(source.datastreams[ds.to_s], target.attached_files[ds.to_s])
+        mover = FedoraMigrate::DatastreamMover.new(source.datastreams[ds.to_s], target.attached_files[ds.to_s], options)
         mover.migrate
       end
     end

--- a/spec/integration/content_versions_spec.rb
+++ b/spec/integration/content_versions_spec.rb
@@ -9,6 +9,14 @@ describe "Versioned content" do
     )
   end
 
+  let(:application_mover) do
+    FedoraMigrate::DatastreamMover.new(
+      FedoraMigrate.source.connection.find("sufia:rb68xc089").datastreams["content"], 
+      ExampleModel::VersionedContent.create.attached_files["content"],
+      { application_creates_versions: true }
+    )
+  end
+
   it "calls the before and after hooks when migrating" do
     expect(mover).to receive(:before_datastream_migration)
     expect(mover).to receive(:after_datastream_migration)
@@ -27,7 +35,16 @@ describe "Versioned content" do
       expect(subject.mime_type).to eql "image/png"
       expect(subject.original_name).to eql "world.png"
     end
-  end
+    context "and the application creates the versions" do
+      subject do
+        application_mover.migrate
+        application_mover.target
+      end
+      it "FedoraMigrate creates no versions" do
+        expect(subject.versions.count).to eql 0
+      end
+    end
+  end 
 
   context "without migrating versions" do
     subject do

--- a/spec/unit/migration_options_spec.rb
+++ b/spec/unit/migration_options_spec.rb
@@ -18,22 +18,44 @@ describe FedoraMigrate::MigrationOptions do
     it { is_expected.to be_not_forced }
   end
 
-  describe "forced?" do
-    subject do
-      TestCase.new.tap do |example|
-        example.options = { convert: "datastream", force: true }
+  describe "#forced?" do
+    context "when set to true" do
+      subject do
+        TestCase.new.tap do |example|
+          example.options = { convert: "datastream", force: true }
+        end
       end
+      it { is_expected.to be_forced }
     end
-    it { is_expected.to be_forced }
+    context "when set to false" do
+      subject do
+        TestCase.new.tap do |example|
+          example.options = { force: false }
+        end
+      end
+      it { is_expected.to be_not_forced }
+    end
+    context "by default" do
+      subject { TestCase.new }
+      it { is_expected.to be_not_forced }
+    end
   end
 
-  describe "forced?" do
-    subject do
-      TestCase.new.tap do |example|
-        example.options = { convert: "datastream", force: false }
+  describe "#application_creates_versions" do
+    context "by default" do
+      subject do
+        TestCase.new.application_creates_versions?
       end
+      it { is_expected.to be false }
     end
-    it { is_expected.to be_not_forced }
+    context "when our own Hydra application creates versions" do
+      subject do
+        TestCase.new.tap do |example|
+          example.options = { application_creates_versions: true }
+        end
+      end
+      it { is_expected.to be_application_creates_versions }
+    end
   end
 
 end


### PR DESCRIPTION
If FedoraMigrate is included in another application that is already creating versions for attached files, then FedoraMigrate should not create versions when migrating. Otherwise, there are two versions for every one original version. Here we pass an option that lets the included application create the version. By default, however, FedoraMigrate will create the versions such as if it is used outside the context of a Hydra application, or one in which no versions are automatically created.