### PR TITLE
Adding ContentMover

### DIFF
--- a/lib/fedora-migrate.rb
+++ b/lib/fedora-migrate.rb
@@ -9,6 +9,7 @@ Dir[File.expand_path(File.join(File.dirname(__FILE__),"tasks/*.rake"))].each { |
 module FedoraMigrate
   extend ActiveSupport::Autoload
 
+  autoload :ContentMover
   autoload :DatastreamMover
   autoload :DatastreamVerification
   autoload :DatesMover

--- a/lib/fedora_migrate/content_mover.rb
+++ b/lib/fedora_migrate/content_mover.rb
@@ -1,0 +1,49 @@
+module FedoraMigrate
+  class ContentMover < Mover
+
+    def migrate
+      return nil_content_message if source.content.nil?
+      move_content
+      insert_date_created_by_application
+    end
+
+    def move_content
+      target.content = source.content
+      target.original_name = source.label.try(:gsub, /"/, '\"')
+      target.mime_type = source.mimeType
+      Logger.info "#{target.inspect}"
+      save
+    end
+
+    def insert_date_created_by_application
+      result = perform_sparql_insert
+      return true if result.status == 204
+      raise FedoraMigrate::Errors::MigrationError, "problem with sparql #{result.status} #{result.body}"
+    end
+
+    def sparql_insert
+<<-EOF
+PREFIX premis: <http://www.loc.gov/premis/rdf/v1#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+DELETE WHERE { ?s premis:hasDateCreatedByApplication ?o } ;
+INSERT {
+  <> premis:hasDateCreatedByApplication "#{source.createDate.iso8601}"^^xsd:dateTime .
+}
+WHERE { }
+EOF
+    end
+
+    private
+
+    def nil_content_message
+      Logger.info "datastream '#{source.dsid}' is nil. It's probably defined in the target but not present in the source"
+      true
+    end
+
+    def perform_sparql_insert
+      ActiveFedora.fedora.connection.patch(target.metadata.metadata_uri, sparql_insert, "Content-Type" => "application/sparql-update")
+    end
+
+  end
+
+end

--- a/spec/integration/versions_spec.rb
+++ b/spec/integration/versions_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe "Versions" do
+
+  let(:source) { FedoraMigrate.source.connection.find("sufia:rb68xc089") }
+  let(:mover)  { FedoraMigrate::ObjectMover.new source, ExampleModel::MigrationObject.new }
+
+  subject do
+    mover.migrate
+    mover.target
+  end
+
+  # Query the metadata node for a given version and return its hasDateCreatedByApplication expressed as an integer
+  def date_created_by_application version
+    uri = subject.content.versions.with_label(version).uri
+    response = ActiveFedora.fedora.connection.get(uri+"/fcr:metadata")
+    graph = ::RDF::Graph.new << ::RDF::Reader.for(:ttl).new(response.body)
+    value = graph.query(predicate: RDF::URI("http://www.loc.gov/premis/rdf/v1#hasDateCreatedByApplication")).first.object.to_s
+    DateTime.iso8601(value).to_i
+  end
+
+  def desc_metadata_source_versions
+    source.datastreams["descMetadata"].versions.sort { |a,b| a.createDate <=> b.createDate }
+  end
+
+  it "should be migrated in the order they were created with their original creation dates" do
+    expect(desc_metadata_source_versions[0].createDate.to_i).to eql date_created_by_application("version1")
+    expect(desc_metadata_source_versions[1].createDate.to_i).to eql date_created_by_application("version2")
+    expect(desc_metadata_source_versions[2].createDate.to_i).to eql date_created_by_application("version3")
+  end
+
+end

--- a/spec/unit/content_mover_spec.rb
+++ b/spec/unit/content_mover_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe FedoraMigrate::ContentMover do
+
+  let(:nil_source) { double("Source", content: nil, dsid: "datastream") }
+  let(:source) do
+    double("Source", 
+      content: "foo", 
+      dsid: "datastream",
+      label: "label",
+      mimeType: "mimetype",
+      createDate: Time.new(1993, 02, 24, 12, 0, 0, "+09:00")  # Rubydora returns Time objects for datastreams' creation dates
+    )
+  end
+  let(:target) { double("Target", content: "") }
+
+  describe "#migrate" do
+    context "without content" do
+      subject { FedoraMigrate::ContentMover.new(nil_source, target).migrate }
+      it { is_expected.to be true }
+    end
+    context "with content" do
+      subject { FedoraMigrate::ContentMover.new(source, target).migrate }
+      before do
+        allow_any_instance_of(FedoraMigrate::ContentMover).to receive(:move_content).and_return(true)
+        allow_any_instance_of(FedoraMigrate::ContentMover).to receive(:insert_date_created_by_application).and_return(true)
+      end
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "#move_content" do
+    before do
+      allow(target).to receive(:content=).with("foo")
+      allow(target).to receive(:original_name=).with("label")
+      allow(target).to receive(:mime_type=).with("mimetype")
+      allow(target).to receive(:save).and_return(true)
+      allow_any_instance_of(FedoraMigrate::ContentMover).to receive(:insert_date_created_by_application).and_return(true)
+    end
+    subject do  
+      FedoraMigrate::ContentMover.new(source, target).move_content
+    end
+    it { is_expected.to be true }
+  end
+
+  describe "#insert_date_created_by_application" do
+    subject { FedoraMigrate::ContentMover.new(source, target).insert_date_created_by_application }
+    context "with a successful update" do
+      let(:successful_status) { double("Result", status: 204) }
+      before { allow_any_instance_of(FedoraMigrate::ContentMover).to receive(:perform_sparql_insert).and_return(successful_status) }
+      it { is_expected.to be true }
+    end
+    context "with an unsuccessful update" do
+      let(:unsuccessful_status) { double("Result", status: 404, body: "Error!") }
+      before { allow_any_instance_of(FedoraMigrate::ContentMover).to receive(:perform_sparql_insert).and_return(unsuccessful_status) }
+      it "should raise an error" do
+        expect { subject }.to raise_error FedoraMigrate::Errors::MigrationError
+      end
+    end
+  end
+
+  describe "#sparql_insert" do
+    let(:sample_sparql_query) do
+<<-EOF
+PREFIX premis: <http://www.loc.gov/premis/rdf/v1#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+DELETE WHERE { ?s premis:hasDateCreatedByApplication ?o } ;
+INSERT {
+  <> premis:hasDateCreatedByApplication "1993-02-24T12:00:00+09:00"^^xsd:dateTime .
+}
+WHERE { }
+EOF
+    end
+    subject { FedoraMigrate::ContentMover.new(source, target).sparql_insert }
+    it { is_expected.to eql sample_sparql_query }
+  end
+
+end


### PR DESCRIPTION
Migrates data and metadata for datastreams and datastream versions, preserving the original creation date using an additional Premis property.