### PR TITLE
Cleanup and refactor RELS-EXT mover

### DIFF
--- a/lib/fedora-migrate.rb
+++ b/lib/fedora-migrate.rb
@@ -2,6 +2,7 @@ require "fedora_migrate/version"
 require "active_support"
 require "active_fedora"
 require "hydra/head"
+require "rubydora"
 
 # Loads rake tasks
 Dir[File.expand_path(File.join(File.dirname(__FILE__),"tasks/*.rake"))].each { |ext| load ext } if defined?(Rake)

--- a/lib/fedora_migrate/mover.rb
+++ b/lib/fedora_migrate/mover.rb
@@ -39,6 +39,18 @@ module FedoraMigrate
         target.inspect
       end
     end
+
+    def id_component object=nil
+      object ||= source
+      raise FedoraMigrate::Errors::MigrationError, "can't get the id component without an object" if object.nil?
+      self.class.id_component(object)
+    end
+
+    def self.id_component object
+      return object.pid.split(/:/).last if object.kind_of?(Rubydora::DigitalObject)
+      return object.to_s.split(/:/).last if object.respond_to?(:to_s)
+      nil
+    end
     
   end
 end

--- a/lib/fedora_migrate/object_mover.rb
+++ b/lib/fedora_migrate/object_mover.rb
@@ -64,9 +64,9 @@ module FedoraMigrate
     end
 
     def create_target_model
-      builder = FedoraMigrate::TargetConstructor.new(@source.models).build
-      raise FedoraMigrate::Errors::MigrationError, "No qualified targets found in #{@source.pid}" if builder.target.nil?
-      @target = builder.target.new(id: @source.pid.split(/:/).last)
+      builder = FedoraMigrate::TargetConstructor.new(source.models).build
+      raise FedoraMigrate::Errors::MigrationError, "No qualified targets found in #{source.pid}" if builder.target.nil?
+      @target = builder.target.new(id: id_component)
     end
 
   end

--- a/lib/fedora_migrate/rubydora_connection.rb
+++ b/lib/fedora_migrate/rubydora_connection.rb
@@ -1,5 +1,3 @@
-require 'rubydora'
-
 module FedoraMigrate
   class RubydoraConnection
     

--- a/lib/fedora_migrate/target_constructor.rb
+++ b/lib/fedora_migrate/target_constructor.rb
@@ -29,7 +29,7 @@ module FedoraMigrate
     end
 
     def vet model
-      @target = model.split(/:/).last.constantize
+      @target = FedoraMigrate::Mover.id_component(model).constantize
       Logger.info "using #{model} for target"
     rescue NameError
       Logger.info "rejecting #{model} for target"

--- a/spec/integration/missing_relationships_spec.rb
+++ b/spec/integration/missing_relationships_spec.rb
@@ -7,20 +7,20 @@ describe "Collections with missing files" do
   let(:missing_file)  { "x346dj07p" }
 
   before do
-    FedoraMigrate::ObjectMover.new(FedoraMigrate.find("scholarsphere:"+collection), ExampleModel::Collection.new(collection)).migrate
-    files.each { |f| FedoraMigrate::ObjectMover.new(FedoraMigrate.find("scholarsphere:"+f), ExampleModel::MigrationObject.new(f)).migrate }
+    FedoraMigrate::ObjectMover.new(FedoraMigrate.find("scholarsphere:#{collection}"), ExampleModel::Collection.new(collection)).migrate
+    files.each { |f| FedoraMigrate::ObjectMover.new(FedoraMigrate.find("scholarsphere:#{f}"), ExampleModel::MigrationObject.new(f)).migrate }
   end
 
   context "when migrating relationships" do
 
-    before do
-      allow(FedoraMigrate::Logger).to receive(:warn)
-      FedoraMigrate::RelsExtDatastreamMover.new(FedoraMigrate.find("scholarsphere:"+collection)).migrate
-    end
+    let(:migrated_collection) { ExampleModel::Collection.first }
+    let(:error_message) do
+      "scholarsphere:#{collection} could not migrate relationship info:fedora/fedora-system:def/relations-external#hasCollectionMember because info:fedora/scholarsphere:#{missing_file} doesn't exist in Fedora 4"
+    end 
 
-    let(:migrated_collection) { ExampleModel::Collection.all.first }
-
-    it "should only migrate existing relationships" do
+    it "should only migrate existing relationships and log failed ones" do
+      expect(FedoraMigrate::Logger).to receive(:warn).with(error_message)
+      FedoraMigrate::RelsExtDatastreamMover.new(FedoraMigrate.find("scholarsphere:#{collection}")).migrate
       expect(migrated_collection.members.count).to eql 2
       expect(migrated_collection.member_ids).to_not include(missing_file)
     end

--- a/spec/unit/mover_spec.rb
+++ b/spec/unit/mover_spec.rb
@@ -7,7 +7,6 @@ describe FedoraMigrate::Mover do
   it { is_expected.to respond_to :options }
 
   describe "#new" do
-    
     context "with two arguments" do
       subject { FedoraMigrate::Mover.new("foo", "bar") }
       specify "has a source" do
@@ -34,6 +33,41 @@ describe FedoraMigrate::Mover do
         expect(subject.target).to be_nil
       end
     end
-
   end
+
+  describe "::id_component" do
+    context "with a Rubydora object" do
+      let(:id)      { "rb68xc11m" }
+      let(:object)  { FedoraMigrate.source.connection.find("sufia:#{id}") }
+      subject { FedoraMigrate::Mover.id_component(object) }
+      it { is_expected.to eql(id) }
+    end
+    context "with a URI" do
+      let(:object)  { RDF::URI.new("foo:bar") }
+      subject { FedoraMigrate::Mover.id_component(object) }
+      it { is_expected.to eql("bar") }
+    end
+    context "with a string" do
+      let(:object)  { "foo:bar" }
+      subject { FedoraMigrate::Mover.id_component(object) }
+      it { is_expected.to eql("bar") }
+    end
+  end
+
+  describe "#id_component" do
+    context "with a source" do
+      subject { FedoraMigrate::Mover.new("source:pid").id_component }
+      it { is_expected.to eql("pid") }
+    end
+    context "object, but no source" do
+      subject { FedoraMigrate::Mover.new.id_component("source:pid") }
+      it { is_expected.to eql("pid") }
+    end
+    context "neither object, nor source" do
+      specify "raises an error" do
+        expect { FedoraMigrate::Mover.new.id_component }.to raise_error(FedoraMigrate::Errors::MigrationError)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Addresses some issues raised in PR #29 that went unanswered. Uses a general method for retrieving the Fedora 4 id from a Rubydora object.