### PR TITLE
Replace logging with a JSON reporting object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ mkmf.log
 jetty
 .ruby-version
 .rvmrc
+report.json

--- a/lib/fedora-migrate.rb
+++ b/lib/fedora-migrate.rb
@@ -56,6 +56,12 @@ module FedoraMigrate
       migrator = FedoraMigrate::RepositoryMigrator.new(args[:namespace], args[:options])
       migrator.migrate_objects
       migrator.migrate_relationships
+      migrator
+    end
+
+    def save_report report
+      json = JSON.load(report.to_json)
+      File.write("report.json", JSON.pretty_generate(json))
     end
 
   end

--- a/lib/fedora_migrate/content_mover.rb
+++ b/lib/fedora_migrate/content_mover.rb
@@ -1,24 +1,44 @@
 module FedoraMigrate
   class ContentMover < Mover
 
+    include DatastreamVerification
+
+    class Report
+      attr_accessor :name, :mime_type, :original_date, :error
+      def success?
+        error.nil?
+      end
+    end
+
     def migrate
-      return nil_content_message if source.content.nil?
+      return report if nil_source
       move_content
+      report_results
       insert_date_created_by_application
+      super
+    end
+
+    def results_report
+      Report.new
     end
 
     def move_content
       target.content = source.content
       target.original_name = source.label.try(:gsub, /"/, '\"')
       target.mime_type = source.mimeType
-      Logger.info "#{target.inspect}"
       save
+      report.error = "Failed checksum" unless valid?
+    end
+
+    def report_results
+      report.name = target.original_name
+      report.mime_type = target.mime_type
     end
 
     def insert_date_created_by_application
-      result = perform_sparql_insert
-      return true if result.status == 204
-      raise FedoraMigrate::Errors::MigrationError, "problem with sparql #{result.status} #{result.body}"
+      result = perform_sparql_insert 
+      report.original_date = source.createDate.iso8601
+      report.error = "There was a problem with sparql #{result.status} #{result.body}" unless result.status == 204
     end
 
     def sparql_insert
@@ -35,13 +55,15 @@ EOF
 
     private
 
-    def nil_content_message
-      Logger.info "datastream '#{source.dsid}' is nil. It's probably defined in the target but not present in the source"
-      true
-    end
-
     def perform_sparql_insert
       ActiveFedora.fedora.connection.patch(target.metadata.metadata_uri, sparql_insert, "Content-Type" => "application/sparql-update")
+    end
+
+    def nil_source
+      if source.content.nil?
+        report.error = "Nil source -- it's probably defined in the target but not present in the source"
+        true
+      end
     end
 
   end

--- a/lib/fedora_migrate/datastream_verification.rb
+++ b/lib/fedora_migrate/datastream_verification.rb
@@ -4,9 +4,7 @@ module FedoraMigrate::DatastreamVerification
 
   def valid? datastream=nil
     @datastream = datastream || @source
-    check = has_matching_checksums? || has_matching_nokogiri_checksums?
-    FedoraMigrate::Logger.warn "#{@datastream.pid} datastream #{@datastream.dsid} validation failed" unless check
-    check
+    has_matching_checksums? || has_matching_nokogiri_checksums?
   end
 
   def has_matching_checksums?

--- a/lib/fedora_migrate/dates_mover.rb
+++ b/lib/fedora_migrate/dates_mover.rb
@@ -1,13 +1,26 @@
 module FedoraMigrate
   class DatesMover < Mover
 
+    Report = Struct.new(:uploaded, :modified)
+
     def migrate
-      if source.respond_to?(:createdDate) && target.respond_to?(:date_uploaded)
-        target.date_uploaded = source.createdDate
-      end
-      if source.respond_to?(:lastModifiedDate) && target.respond_to?(:date_modified)
-        target.date_modified = source.lastModifiedDate
-      end
+      migrate_date_uploaded if source.respond_to?(:createdDate) && target.respond_to?(:date_uploaded)
+      migrate_date_modified if source.respond_to?(:lastModifiedDate) && target.respond_to?(:date_modified)
+      super
+    end
+
+    def results_report
+      Report.new
+    end
+
+    def migrate_date_uploaded
+      target.date_uploaded = source.createdDate
+      report.uploaded = source.createdDate
+    end
+
+    def migrate_date_modified
+      target.date_modified = source.lastModifiedDate
+      report.modified = source.lastModifiedDate
     end
 
   end

--- a/lib/fedora_migrate/mover.rb
+++ b/lib/fedora_migrate/mover.rb
@@ -4,37 +4,34 @@ module FedoraMigrate
     include MigrationOptions
     include Hooks
 
-    attr_accessor :target, :source
+    attr_accessor :target, :source, :report
 
     def initialize *args
       @source = args[0]
       @target = args[1]
       @options = args[2]
+      @report = results_report
       post_initialize
     end
 
     def post_initialize
     end
 
+    def results_report
+      []
+    end
+
+    def migrate
+      report
+    end
+
     def save
-      if target.save
-        Logger.info "success for target UID #{target_description}"
-      else
-        raise FedoraMigrate::Errors::MigrationError, "Failed to save target: #{target_errors}"
-      end
+      raise FedoraMigrate::Errors::MigrationError, "Failed to save target: #{target_errors}" unless target.save
     end
 
     def target_errors
       if target.respond_to?(:errors)
         target.errors.full_messages.join(" -- ")
-      else
-        target.inspect
-      end
-    end
-
-    def target_description
-      if target.respond_to?(:id)
-        target.id
       else
         target.inspect
       end

--- a/lib/fedora_migrate/permissions_mover.rb
+++ b/lib/fedora_migrate/permissions_mover.rb
@@ -13,12 +13,12 @@ module FedoraMigrate
 
     def migrate
       FedoraMigrate::Permissions.instance_methods.each do |permission|
-        Logger.info "setting #{permission} to #{self.send(permission)}"
+        report << "#{permission} = #{self.send(permission)}"
         target.send(permission.to_s+"=", self.send(permission))
       end
       save
+      super
     end
-
 
     private
 

--- a/lib/fedora_migrate/rdf_datastream_mover.rb
+++ b/lib/fedora_migrate/rdf_datastream_mover.rb
@@ -4,11 +4,11 @@ module FedoraMigrate
   class RDFDatastreamMover < Mover
 
     def migrate
-      Logger.info "converting datastream '#{source.dsid}' to RDF"
       before_rdf_datastream_migration
       migrate_rdf_triples
       after_rdf_datastream_migration
       save
+      super
     end
 
     def migrate_rdf_triples

--- a/lib/fedora_migrate/rels_ext_datastream_mover.rb
+++ b/lib/fedora_migrate/rels_ext_datastream_mover.rb
@@ -7,6 +7,7 @@ module FedoraMigrate
       migrate_statements
       target.ldp_source.update
       update_index
+      super
     end
 
     def post_initialize
@@ -19,7 +20,9 @@ module FedoraMigrate
 
     def migrate_statements
       statements.each do |statement|
-        target.ldp_source.graph << [target.rdf_subject, migrate_predicate(statement.predicate), migrate_object(statement.object)]
+        triple = [target.rdf_subject, migrate_predicate(statement.predicate), migrate_object(statement.object)]
+        target.ldp_source.graph << triple
+        report << triple.join("--")
       end
     end
 
@@ -43,7 +46,7 @@ module FedoraMigrate
 
     def has_missing_object?(statement)
       return false if ActiveFedora::Base.exists?(id_component(statement.object))
-      Logger.warn "#{source.pid} could not migrate relationship #{statement.predicate} because #{statement.object} doesn't exist in Fedora 4"
+      report << "could not migrate relationship #{statement.predicate} because #{statement.object} doesn't exist in Fedora 4"
       true
     end
 

--- a/lib/fedora_migrate/target_constructor.rb
+++ b/lib/fedora_migrate/target_constructor.rb
@@ -30,9 +30,8 @@ module FedoraMigrate
 
     def vet model
       @target = FedoraMigrate::Mover.id_component(model).constantize
-      Logger.info "using #{model} for target"
     rescue NameError
-      Logger.info "rejecting #{model} for target"
+      Logger.debug "rejecting #{model} for target"
     end
 
   end

--- a/spec/integration/repository_migration_spec.rb
+++ b/spec/integration/repository_migration_spec.rb
@@ -10,9 +10,11 @@ describe "Migrating the repository" do
       Object.send(:remove_const, :Collection) if defined?(Collection)
     end
 
-    it "should log warnings" do
-      expect(FedoraMigrate::Logger).to receive(:warn).at_least(6).times
-      FedoraMigrate.migrate_repository(namespace: "sufia", options: {convert: "descMetadata"})
+    subject { FedoraMigrate.migrate_repository(namespace: "sufia", options: {convert: "descMetadata"}).report }
+
+    it "should report warnings" do
+      expect(subject.map { |k,v| v.status }.count).to eql 9
+      expect(subject.map { |k,v| v.status }.uniq).to eql [false]
     end
   end
 

--- a/spec/unit/content_mover_spec.rb
+++ b/spec/unit/content_mover_spec.rb
@@ -12,12 +12,15 @@ describe FedoraMigrate::ContentMover do
       createDate: Time.new(1993, 02, 24, 12, 0, 0, "+09:00")  # Rubydora returns Time objects for datastreams' creation dates
     )
   end
-  let(:target) { double("Target", content: "") }
+  let(:target) { double("Target", content: "", original_name: nil, mime_type: nil) }
 
   describe "#migrate" do
     context "without content" do
       subject { FedoraMigrate::ContentMover.new(nil_source, target).migrate }
-      it { is_expected.to be true }
+      it "reports a nil source" do
+        expect(subject).to be_kind_of FedoraMigrate::ContentMover::Report
+        expect(subject.error).to eql "Nil source -- it's probably defined in the target but not present in the source"
+      end
     end
     context "with content" do
       subject { FedoraMigrate::ContentMover.new(source, target).migrate }
@@ -25,7 +28,7 @@ describe FedoraMigrate::ContentMover do
         allow_any_instance_of(FedoraMigrate::ContentMover).to receive(:move_content).and_return(true)
         allow_any_instance_of(FedoraMigrate::ContentMover).to receive(:insert_date_created_by_application).and_return(true)
       end
-      it { is_expected.to be true }
+      it { is_expected.to be_kind_of FedoraMigrate::ContentMover::Report }
     end
   end
 
@@ -34,13 +37,19 @@ describe FedoraMigrate::ContentMover do
       allow(target).to receive(:content=).with("foo")
       allow(target).to receive(:original_name=).with("label")
       allow(target).to receive(:mime_type=).with("mimetype")
-      allow(target).to receive(:save).and_return(true)
-      allow_any_instance_of(FedoraMigrate::ContentMover).to receive(:insert_date_created_by_application).and_return(true)
+      allow(target).to receive(:save).and_return(true)   
     end
     subject do  
       FedoraMigrate::ContentMover.new(source, target).move_content
     end
-    it { is_expected.to be true }
+    context "with a valid checksum" do
+      before { allow_any_instance_of(FedoraMigrate::ContentMover).to receive(:valid?).and_return(true) }
+      it { is_expected.to be nil }
+    end
+    context "with an invalid checksum" do
+      before { allow_any_instance_of(FedoraMigrate::ContentMover).to receive(:valid?).and_return(false) }
+      it { is_expected.to eql "Failed checksum" }
+    end
   end
 
   describe "#insert_date_created_by_application" do
@@ -48,14 +57,12 @@ describe FedoraMigrate::ContentMover do
     context "with a successful update" do
       let(:successful_status) { double("Result", status: 204) }
       before { allow_any_instance_of(FedoraMigrate::ContentMover).to receive(:perform_sparql_insert).and_return(successful_status) }
-      it { is_expected.to be true }
+      it { is_expected.to be nil }
     end
     context "with an unsuccessful update" do
       let(:unsuccessful_status) { double("Result", status: 404, body: "Error!") }
       before { allow_any_instance_of(FedoraMigrate::ContentMover).to receive(:perform_sparql_insert).and_return(unsuccessful_status) }
-      it "should raise an error" do
-        expect { subject }.to raise_error FedoraMigrate::Errors::MigrationError
-      end
+      it { is_expected.to eql "There was a problem with sparql 404 Error!" }
     end
   end
 

--- a/spec/unit/datastream_verification_spec.rb
+++ b/spec/unit/datastream_verification_spec.rb
@@ -23,10 +23,7 @@ describe FedoraMigrate::DatastreamVerification do
     context "that do not match Fedora4's checksum" do
       subject { TestSubject.new(bad_binary_source) }
       before  { allow(subject).to receive(:target_checksum).twice.and_return("bar") }
-      specify "are not valid and logged" do
-        expect(FedoraMigrate::Logger).to receive(:warn)
-        expect(subject).to_not be_valid
-      end
+      it      { is_expected.to_not be_valid }
     end
     context "when the checksum is missing" do
       subject { TestSubject.new(missing_checksum) }
@@ -37,10 +34,7 @@ describe FedoraMigrate::DatastreamVerification do
       end
       context "and a newly calculated checksum does not match" do
         before { expect_any_instance_of(TestSubject).to receive(:target_checksum).twice.and_return(Digest::SHA1.hexdigest("bar")) }
-        specify "are not valid and logged" do
-          expect(FedoraMigrate::Logger).to receive(:warn)
-          expect(subject).to_not be_valid
-        end
+        it     { is_expected.to_not be_valid }
       end
     end
   end

--- a/spec/unit/object_mover_spec.rb
+++ b/spec/unit/object_mover_spec.rb
@@ -14,7 +14,7 @@ describe FedoraMigrate::ObjectMover do
 
   describe "#prepare_target" do
     subject do
-      FedoraMigrate::ObjectMover.new("source", "target").prepare_target
+      FedoraMigrate::ObjectMover.new("source", double("Target", id: nil)).prepare_target
     end
     it "should call the before hook and save the target" do
       expect_any_instance_of(FedoraMigrate::ObjectMover).to receive(:before_object_migration)
@@ -24,7 +24,7 @@ describe FedoraMigrate::ObjectMover do
 
   describe "#complete_target" do
     subject do
-      FedoraMigrate::ObjectMover.new("source", "target").complete_target
+      FedoraMigrate::ObjectMover.new("source", double("Target", id: nil)).complete_target
     end
     it "should call the after hook and save the target" do
       expect_any_instance_of(FedoraMigrate::ObjectMover).to receive(:after_object_migration)


### PR DESCRIPTION
Instead of logging errors to STDERR, return a JSON object with nested reports from each mover, representing the results of each step of the migration process for each object.

@cam156 @mjgiarlo would like your thoughts on this. There would be forthcoming PRs that use the resulting JSON report to re-run migrations for failed objects and interpret the report to give the user stats on what failed.