### PR TITLE
MigrationReport to track failures and results

### DIFF
--- a/lib/fedora-migrate.rb
+++ b/lib/fedora-migrate.rb
@@ -19,6 +19,7 @@ module FedoraMigrate
   autoload :Hooks
   autoload :Logger
   autoload :MigrationOptions
+  autoload :MigrationReport
   autoload :Mover
   autoload :ObjectMover
   autoload :Permissions
@@ -33,15 +34,11 @@ module FedoraMigrate
   autoload :TripleConverter
 
   class << self
-    attr_reader :fedora_config, :config_options, :source
+    attr_reader :fedora_config, :source
     attr_accessor :configurator
 
     def fedora_config
       @fedora_config ||= ActiveFedora::Config.new(configurator.fedora3_config)
-    end
-
-    def config_options
-      @config_options ||= "comming soon!"
     end
 
     def source
@@ -57,11 +54,6 @@ module FedoraMigrate
       migrator.migrate_objects
       migrator.migrate_relationships
       migrator
-    end
-
-    def save_report report
-      json = JSON.load(report.to_json)
-      File.write("report.json", JSON.pretty_generate(json))
     end
 
   end

--- a/lib/fedora_migrate/migration_report.rb
+++ b/lib/fedora_migrate/migration_report.rb
@@ -1,0 +1,40 @@
+module FedoraMigrate
+  class MigrationReport
+
+    attr_accessor :results
+
+    def initialize report=nil
+      @results = report.nil? ? Hash.new : JSON.parse(File.read(report))
+    end
+
+    def empty?
+      results.empty?
+    end
+
+    def failed_objects
+      results.keys.map { |k| k unless results[k]["status"] }.compact
+    end
+
+    def failures
+      failed_objects.count
+    end
+
+    def total_objects
+      results.keys.count
+    end
+
+    def report_failures output = String.new
+      failed_objects.each do |k|
+        output << "#{k}:\n\tobject: #{results[k]["object"]}\n\trelationships: #{results[k]["relationships"]}\n\n"
+      end
+      output
+    end
+
+    def save path=nil
+      json = JSON.load(results.to_json)
+      file = path.nil? ? "report.json" : File.join(path,"report.json")
+      File.write(file, JSON.pretty_generate(json))
+    end
+
+  end
+end

--- a/lib/tasks/fedora-migrate.rake
+++ b/lib/tasks/fedora-migrate.rake
@@ -8,8 +8,8 @@ namespace :fedora do
   namespace :migrate do
     desc "Migrates all objects in a Sufia-based application"
     task sufia: :environment do
-      results = FedoraMigrate.migrate_repository(namespace: "sufia", options: {convert: "descMetadata"})
-      puts results
+      migrator = FedoraMigrate.migrate_repository(namespace: "sufia", options: {convert: "descMetadata"})
+      migrator.report.save
     end
 
     desc "Migrates only relationships in a Sufia-based application"
@@ -38,6 +38,12 @@ namespace :fedora do
     task :relationship, [:pid] => :environment do |t, args|
       raise "Please provide a pid, example changeme:1234" if args[:pid].nil?
       FedoraMigrate::RelsExtDatastreamMover.new(FedoraMigrate.source.connection.find(args[:pid])).migrate
+    end
+
+    desc "Report the results of a migration"
+    task :report, [:file] => :environment do |t, args|
+      raise "Please provide a path to a report.json file" if args[:file].nil?
+      FedoraMigrate::MigrationReport.new(args[:file]).report_failures
     end
   
   end

--- a/spec/fixtures/failed-report.json
+++ b/spec/fixtures/failed-report.json
@@ -1,0 +1,339 @@
+{
+  "sufia:5m60qr94g": {
+    "status": false,
+    "object": "Sample object migration failure",
+    "relationships": [
+
+    ]
+  },
+  "sufia:5m60qr95r": {
+    "status": true,
+    "object": {
+      "id": "5m60qr95r",
+      "class": "GenericFile",
+      "content_datastreams": [
+        {
+          "ds": "content",
+          "versions": [
+            {
+              "name": "file2.txt",
+              "mime_type": "text/plain",
+              "original_date": "2015-01-19T21:32:47Z"
+            }
+          ]
+        },
+        {
+          "ds": "thumbnail",
+          "versions": [
+            {
+              "error": "Nil source -- it's probably defined in the target but not present in the source"
+            }
+          ]
+        },
+        {
+          "ds": "characterization",
+          "versions": [
+            {
+              "error": "Nil source -- it's probably defined in the target but not present in the source"
+            }
+          ]
+        }
+      ],
+      "rdf_datastreams": [
+        {
+          "ds": "descMetadata",
+          "status": [
+
+          ]
+        }
+      ],
+      "permissions": [
+        "read_groups = []",
+        "edit_groups = []",
+        "discover_groups = []",
+        "read_users = []",
+        "edit_users = [\"awead@psu.edu\"]",
+        "discover_users = []"
+      ],
+      "dates": {
+        "uploaded": null,
+        "modified": null
+      }
+    },
+    "relationships": [
+      "http://localhost:8983/fedora/rest/test/5m60qr95r--info:fedora/fedora-system:def/relations-external#isPartOf--http://localhost:8983/fedora/rest/test/5m60qr94g"
+    ]
+  },
+  "sufia:5m60qr961": {
+    "status": true,
+    "object": {
+      "id": "5m60qr961",
+      "class": "GenericFile",
+      "content_datastreams": [
+        {
+          "ds": "content",
+          "versions": [
+            {
+              "name": "file1.txt",
+              "mime_type": "text/plain",
+              "original_date": "2015-01-19T21:32:49Z"
+            }
+          ]
+        },
+        {
+          "ds": "thumbnail",
+          "versions": [
+            {
+              "error": "Nil source -- it's probably defined in the target but not present in the source"
+            }
+          ]
+        },
+        {
+          "ds": "characterization",
+          "versions": [
+            {
+              "error": "Nil source -- it's probably defined in the target but not present in the source"
+            }
+          ]
+        }
+      ],
+      "rdf_datastreams": [
+        {
+          "ds": "descMetadata",
+          "status": [
+
+          ]
+        }
+      ],
+      "permissions": [
+        "read_groups = []",
+        "edit_groups = []",
+        "discover_groups = []",
+        "read_users = []",
+        "edit_users = [\"awead@psu.edu\"]",
+        "discover_users = []"
+      ],
+      "dates": {
+        "uploaded": null,
+        "modified": null
+      }
+    },
+    "relationships": [
+      "http://localhost:8983/fedora/rest/test/5m60qr961--info:fedora/fedora-system:def/relations-external#isPartOf--http://localhost:8983/fedora/rest/test/5m60qr94g"
+    ]
+  },
+  "sufia:5m60qr979": {
+    "status": true,
+    "object": {
+      "id": "5m60qr979",
+      "class": "Collection",
+      "content_datastreams": [
+
+      ],
+      "rdf_datastreams": [
+        {
+          "ds": "descMetadata",
+          "status": [
+
+          ]
+        }
+      ],
+      "permissions": [
+        "read_groups = [\"public\"]",
+        "edit_groups = []",
+        "discover_groups = []",
+        "read_users = []",
+        "edit_users = [\"awead@psu.edu\"]",
+        "discover_users = []"
+      ],
+      "dates": {
+        "uploaded": "2015-01-19T21:34:23.805Z",
+        "modified": "2015-03-03T18:48:51.16Z"
+      }
+    },
+    "relationships": [
+      "http://localhost:8983/fedora/rest/test/5m60qr979--info:fedora/fedora-system:def/relations-external#hasCollectionMember--http://localhost:8983/fedora/rest/test/5m60qr95r",
+      "http://localhost:8983/fedora/rest/test/5m60qr979--info:fedora/fedora-system:def/relations-external#hasCollectionMember--http://localhost:8983/fedora/rest/test/5m60qr961"
+    ]
+  },
+  "sufia:rb68xc089": {
+    "status": false,
+    "object": "Sample object migration failure",
+    "relationships": [
+
+    ]
+  },
+  "sufia:rb68xc09k": {
+    "status": true,
+    "object": {
+      "id": "rb68xc09k",
+      "class": "Batch",
+      "content_datastreams": [
+
+      ],
+      "rdf_datastreams": [
+
+      ],
+      "permissions": null,
+      "dates": {
+        "uploaded": null,
+        "modified": null
+      }
+    },
+    "relationships": [
+
+    ]
+  },
+  "sufia:rb68xc10b": {
+    "status": true,
+    "object": {
+      "id": "rb68xc10b",
+      "class": "GenericFile",
+      "content_datastreams": [
+        {
+          "ds": "content",
+          "versions": [
+
+          ]
+        },
+        {
+          "ds": "thumbnail",
+          "versions": [
+            {
+              "error": "Nil source -- it's probably defined in the target but not present in the source"
+            }
+          ]
+        },
+        {
+          "ds": "characterization",
+          "versions": [
+            {
+              "error": "Nil source -- it's probably defined in the target but not present in the source"
+            }
+          ]
+        }
+      ],
+      "rdf_datastreams": [
+
+      ],
+      "permissions": [
+        "read_groups = []",
+        "edit_groups = []",
+        "discover_groups = []",
+        "read_users = []",
+        "edit_users = [\"jilluser@example.com\"]",
+        "discover_users = []"
+      ],
+      "dates": {
+        "uploaded": null,
+        "modified": null
+      }
+    },
+    "relationships": [
+      "http://localhost:8983/fedora/rest/test/rb68xc10b--info:fedora/fedora-system:def/relations-external#isPartOf--http://localhost:8983/fedora/rest/test/rb68xc09k"
+    ]
+  },
+  "sufia:rb68xc11m": {
+    "status": true,
+    "object": {
+      "id": "rb68xc11m",
+      "class": "GenericFile",
+      "content_datastreams": [
+        {
+          "ds": "content",
+          "versions": [
+
+          ]
+        },
+        {
+          "ds": "thumbnail",
+          "versions": [
+            {
+              "error": "Nil source -- it's probably defined in the target but not present in the source"
+            }
+          ]
+        },
+        {
+          "ds": "characterization",
+          "versions": [
+            {
+              "error": "Nil source -- it's probably defined in the target but not present in the source"
+            }
+          ]
+        }
+      ],
+      "rdf_datastreams": [
+
+      ],
+      "permissions": [
+        "read_groups = []",
+        "edit_groups = []",
+        "discover_groups = []",
+        "read_users = []",
+        "edit_users = [\"otherUser\"]",
+        "discover_users = []"
+      ],
+      "dates": {
+        "uploaded": null,
+        "modified": null
+      }
+    },
+    "relationships": [
+      "http://localhost:8983/fedora/rest/test/rb68xc11m--info:fedora/fedora-system:def/relations-external#isPartOf--http://localhost:8983/fedora/rest/test/rb68xc09k"
+    ]
+  },
+  "sufia:xp68km39w": {
+    "status": true,
+    "object": {
+      "id": "xp68km39w",
+      "class": "GenericFile",
+      "content_datastreams": [
+        {
+          "ds": "content",
+          "versions": [
+
+          ]
+        },
+        {
+          "ds": "thumbnail",
+          "versions": [
+            {
+              "error": "Nil source -- it's probably defined in the target but not present in the source"
+            }
+          ]
+        },
+        {
+          "ds": "characterization",
+          "versions": [
+            {
+              "error": "Nil source -- it's probably defined in the target but not present in the source"
+            }
+          ]
+        }
+      ],
+      "rdf_datastreams": [
+        {
+          "ds": "descMetadata",
+          "status": [
+
+          ]
+        }
+      ],
+      "permissions": [
+        "read_groups = []",
+        "edit_groups = []",
+        "discover_groups = []",
+        "read_users = []",
+        "edit_users = [\"awead@psu.edu\"]",
+        "discover_users = []"
+      ],
+      "dates": {
+        "uploaded": null,
+        "modified": null
+      }
+    },
+    "relationships": [
+
+    ]
+  }
+}

--- a/spec/fixtures/sample-report.json
+++ b/spec/fixtures/sample-report.json
@@ -1,0 +1,166 @@
+{
+  "scholarsphere:000000000": {
+    "status": true,
+    "object": {
+      "id": "000000000",
+      "class": "Batch",
+      "content_datastreams": [
+
+      ],
+      "rdf_datastreams": [
+        {
+          "ds": "descMetadata",
+          "status": [
+
+          ]
+        }
+      ],
+      "permissions": null,
+      "dates": {
+        "uploaded": null,
+        "modified": null
+      }
+    },
+    "relationships": [
+
+    ]
+  },
+  "scholarsphere:000000018": {
+    "status": true,
+    "object": {
+      "id": "000000018",
+      "class": "GenericFile",
+      "content_datastreams": [
+        {
+          "ds": "characterization",
+          "versions": [
+            {
+              "name": "",
+              "mime_type": "text/xml",
+              "original_date": "2013-03-15T11:08:21Z"
+            }
+          ]
+        },
+        {
+          "ds": "content",
+          "versions": [
+            {
+              "name": "Open_Up_Your_RepositoryWith_a_SWORD_.pdf",
+              "mime_type": "application/pdf",
+              "original_date": "2012-09-26T16:09:14Z"
+            },
+            {
+              "name": "Open_Up_Your_RepositoryWith_a_SWORD_.pdf",
+              "mime_type": "application/pdf",
+              "original_date": "2012-11-26T03:11:55Z"
+            },
+            {
+              "name": "Open_Up_Your_RepositoryWith_a_SWORD_.pdf",
+              "mime_type": "application/pdf",
+              "original_date": "2012-11-26T03:12:07Z"
+            },
+            {
+              "name": "Open_Up_Your_RepositoryWith_a_SWORD_.pdf",
+              "mime_type": "application/pdf",
+              "original_date": "2012-11-26T03:12:10Z"
+            },
+            {
+              "name": "Open_Up_Your_RepositoryWith_a_SWORD_.pdf",
+              "mime_type": "application/pdf",
+              "original_date": "2012-11-26T03:12:13Z"
+            },
+            {
+              "name": "Open_Up_Your_RepositoryWith_a_SWORD_.pdf",
+              "mime_type": "application/pdf",
+              "original_date": "2012-11-26T03:12:17Z"
+            },
+            {
+              "name": "Open_Up_Your_RepositoryWith_a_SWORD_.pdf",
+              "mime_type": "application/pdf",
+              "original_date": "2012-11-26T03:13:12Z"
+            }
+          ]
+        },
+        {
+          "ds": "thumbnail",
+          "versions": [
+            {
+              "name": "",
+              "mime_type": "image/jpeg",
+              "original_date": "2014-09-10T15:12:43Z"
+            }
+          ]
+        },
+        {
+          "ds": "full_text",
+          "versions": [
+            {
+              "name": "File Datastream",
+              "mime_type": "application/octet-stream",
+              "original_date": "2013-03-14T10:03:13Z"
+            }
+          ]
+        }
+      ],
+      "rdf_datastreams": [
+        {
+          "ds": "descMetadata",
+          "status": [
+
+          ]
+        }
+      ],
+      "permissions": [
+        "read_groups = [\"public\"]",
+        "edit_groups = []",
+        "discover_groups = []",
+        "read_users = []",
+        "edit_users = [\"mjg36\"]",
+        "discover_users = []"
+      ],
+      "dates": {
+        "uploaded": "2012-09-26T16:09:13.394Z",
+        "modified": "2015-01-02T22:16:02.961Z"
+      }
+    },
+    "relationships": [
+      "http://ssrepo2qa.dlt.psu.edu:8080/SSqaFedora4/rest/prod/00/00/00/01/000000018--info:fedora/fedora-system:def/relations-external#isPartOf--http://ssrepo2qa.dlt.psu.edu:8080/SSqaFedora4/rest/prod/00/00/00/00/000000000"
+    ]
+  },
+  "scholarsphere:05741r698": {
+    "status": true,
+    "object": {
+      "id": "05741r698",
+      "class": "Batch",
+      "content_datastreams": [
+
+      ],
+      "rdf_datastreams": [
+        {
+          "ds": "descMetadata",
+          "status": [
+
+          ]
+        }
+      ],
+      "permissions": null,
+      "dates": {
+        "uploaded": null,
+        "modified": null
+      }
+    },
+    "relationships": [
+
+    ]
+  },
+  "scholarsphere:6395wb555": {
+    "status": false,
+    "object": "#<Ldp::BadRequest: RDF was not parsable>",
+    "relationships": "#<FedoraMigrate::Errors::MigrationError: Target object was not found in Fedora 4. Did you migrate it?>"
+  },
+  "scholarsphere:x346dm27k": {
+    "status": false,
+    "object": "#<Ldp::BadRequest: RDF was not parsable>",
+    "relationships": "#<FedoraMigrate::Errors::MigrationError: Target object was not found in Fedora 4. Did you migrate it?>"
+  }
+}

--- a/spec/unit/migration_report_spec.rb
+++ b/spec/unit/migration_report_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe FedoraMigrate::MigrationReport do
+
+  let(:existing_report) { FedoraMigrate::MigrationReport.new("spec/fixtures/sample-report.json") }
+  let(:new_report)      { FedoraMigrate::MigrationReport.new }
+
+  context "with an existing report" do
+    subject { existing_report }
+    it { is_expected.not_to be_empty }
+    describe "::results" do
+      subject { existing_report.results }
+      it { is_expected.to be_kind_of(Hash) }
+    end
+    describe "::failed_objects" do
+      subject { existing_report.failed_objects }
+      it { is_expected.to include("scholarsphere:6395wb555", "scholarsphere:x346dm27k") }
+    end
+    describe "::failures" do
+      subject { existing_report.failures }    
+      context "when the report contains failed migrations" do
+        it { is_expected.to eq 2 }
+      end
+    end
+    describe "::total_objects" do
+      subject { existing_report.total_objects }
+      it { is_expected.to eq 5 }
+    end
+    describe "::report_failures" do
+      subject { existing_report.report_failures }   
+      it { is_expected.to be_kind_of(String) }
+    end
+    describe "::save" do
+      context "with the default path" do
+        it "should write the report" do
+          expect(File).to receive(:write).with("report.json", "{\n}")
+          new_report.save
+        end
+      end
+      context "with a user-provided path" do
+        it "should write the report" do
+          expect(File).to receive(:write).with("foo/path/report.json", "{\n}")
+          new_report.save("foo/path")
+        end
+      end
+    end
+  end
+
+  context "as a new report" do
+    subject { new_report }
+    it { is_expected.to be_empty }
+    describe "::results" do
+      subject { new_report.results }
+      it { is_expected.to be_kind_of(Hash) }
+    end
+  end
+
+end

--- a/spec/unit/repository_migrator_spec.rb
+++ b/spec/unit/repository_migrator_spec.rb
@@ -8,22 +8,30 @@ describe FedoraMigrate::RepositoryMigrator do
   it { is_expected.to respond_to(:report) }
   it { is_expected.to respond_to(:namespace) }
 
+  def mock_report content
+    report = FedoraMigrate::MigrationReport.new 
+    report.results = JSON.parse(content.to_json)
+    report
+  end
+
   describe "#failures" do
     context "when objects have failed to migrate" do
-      let(:failing_report) { { pid1: FedoraMigrate::RepositoryMigrator::Report.new(false, "objects", "relationships") } }
+      let(:failing_report) { { "sufia:rb68xc089" => FedoraMigrate::RepositoryMigrator::SingleObjectReport.new(false, "objects", "relationships") } }
+      before { allow_any_instance_of(FedoraMigrate::RepositoryMigrator).to receive(:report).and_return(mock_report(failing_report)) }
       subject do
-        migrator = FedoraMigrate::RepositoryMigrator.new(namespace, { report: failing_report })
+        migrator = FedoraMigrate::RepositoryMigrator.new(namespace)
         migrator.failures
       end
-      it { is_expected.to be 1}
+      it { is_expected.to be 1 }
     end
     context "when all objects have migrated" do
-      let(:passing_report) { { pid1: FedoraMigrate::RepositoryMigrator::Report.new(true, "objects", "relationships") } }
+      let(:passing_report) { { "sufia:rb68xc089" => FedoraMigrate::RepositoryMigrator::SingleObjectReport.new(true, "objects", "relationships") } }
+      before { allow_any_instance_of(FedoraMigrate::RepositoryMigrator).to receive(:report).and_return(mock_report(passing_report)) }
       subject do
-        migrator = FedoraMigrate::RepositoryMigrator.new(namespace, { report: passing_report })
+        migrator = FedoraMigrate::RepositoryMigrator.new(namespace)
         migrator.failures
       end
-      it { is_expected.to eql 0}
+      it { is_expected.to eql 0 }
     end
   end
 


### PR DESCRIPTION
This builds off of the previous PR that added reporting to the mix.

When the migration is finished, a json file can be written which reports on the results of the migration process. If a migration is redone with the report passed as an option, then only the objects that initially failed in the report will be migrated.