### PR TITLE
Override TargetConstructor

### DIFF
--- a/fedora-migrate.gemspec
+++ b/fedora-migrate.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "jettywrapper"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec-its"
 end

--- a/lib/fedora_migrate/object_mover.rb
+++ b/lib/fedora_migrate/object_mover.rb
@@ -37,6 +37,10 @@ module FedoraMigrate
       save
     end
 
+    def target
+      @target ||= FedoraMigrate::TargetConstructor.new(source).build
+    end
+
     private
 
       def migrate_datastreams
@@ -74,12 +78,6 @@ module FedoraMigrate
 
       def migrate_dates
         report.dates = FedoraMigrate::DatesMover.new(source, target).migrate
-      end
-
-      def create_target_model
-        builder = FedoraMigrate::TargetConstructor.new(source.models).build
-        raise FedoraMigrate::Errors::MigrationError, "No qualified targets found in #{source.pid}" if builder.target.nil?
-        @target = builder.target.new(id: id_component)
       end
   end
 end

--- a/spec/integration/custom_target_spec.rb
+++ b/spec/integration/custom_target_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe FedoraMigrate::ObjectMover do
+  let(:source) { FedoraMigrate.source.connection.find("sufia:rb68xc089") }
+  let(:original_pid) { FedoraMigrate::Mover.id_component(source) }
+
+  context "when we use our own target constructor" do
+    let(:mover) { described_class.new source }
+
+    before do
+      # Override .build to use Fedora's default id minter
+      class FedoraMigrate::TargetConstructor
+        def build
+          target.new
+        end
+      end
+
+      Object.send(:remove_const, :GenericFile) if defined?(GenericFile)
+      class GenericFile < ActiveFedora::Base
+        contains "content", class_name: "ExampleModel::VersionedDatastream"
+        contains "thumbnail", class_name: "ActiveFedora::Datastream"
+        contains "characterization", class_name: "ActiveFedora::Datastream"
+      end
+    end
+
+    after do
+      load './lib/fedora_migrate/target_constructor.rb'
+    end
+
+    subject do
+      mover.migrate
+      mover.target
+    end
+
+    it "migrates the entire object using a different id" do
+      expect(subject.content.versions.all.count).to eql 3
+      expect(subject.thumbnail.mime_type).to eql "image/jpeg"
+      expect(subject.thumbnail.versions.all.count).to eql 0
+      expect(subject.characterization.versions.all.count).to eql 0
+      expect(subject).to be_kind_of GenericFile
+      expect(subject.id).not_to eq(original_pid)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'fedora-migrate'
 require 'equivalent-xml/rspec_matchers'
 require 'support/example_model'
 require 'active_fedora/cleaner'
+require 'rspec/its'
 
 require 'http_logger'
 ActiveFedora::Base.logger = Logger.new(STDERR)

--- a/spec/unit/object_mover_spec.rb
+++ b/spec/unit/object_mover_spec.rb
@@ -1,9 +1,8 @@
 require 'spec_helper'
 
 describe FedoraMigrate::ObjectMover do
-  before do
-    allow_any_instance_of(described_class).to receive(:create_target_model).and_return("foo")
-  end
+  let(:mock_target) { double("Target", id: "1234") }
+  before { allow_any_instance_of(described_class).to receive(:target).and_return(mock_target) }
 
   describe "#new" do
     it { is_expected.to respond_to :source }
@@ -12,9 +11,7 @@ describe FedoraMigrate::ObjectMover do
   end
 
   describe "#prepare_target" do
-    subject do
-      described_class.new("source", double("Target", id: nil)).prepare_target
-    end
+    subject { described_class.new("source", double("Target", id: nil)).prepare_target }
     it "calls the before hook and save the target" do
       expect_any_instance_of(described_class).to receive(:before_object_migration)
       expect(subject).to be nil
@@ -22,9 +19,7 @@ describe FedoraMigrate::ObjectMover do
   end
 
   describe "#complete_target" do
-    subject do
-      described_class.new("source", double("Target", id: nil)).complete_target
-    end
+    subject { described_class.new("source", double("Target", id: nil)).complete_target }
     it "calls the after hook and save the target" do
       expect_any_instance_of(described_class).to receive(:after_object_migration)
       expect_any_instance_of(described_class).to receive(:save).and_return(true)

--- a/spec/unit/target_constructor_spec.rb
+++ b/spec/unit/target_constructor_spec.rb
@@ -1,32 +1,28 @@
 require 'spec_helper'
 
 describe FedoraMigrate::TargetConstructor do
+  let(:mock_source) { instance_double("Source", models: list, pid: "pid:1234") }
   context "with one qualified model" do
     let(:list) { ["info:fedora/fedora-system:FedoraObject-3.0", "info:fedora/afmodel:String"] }
-    subject { described_class.new(list).build }
-    it "chooses the one that is valid" do
-      expect(subject.target).to eql String
-    end
+    subject { described_class.new(mock_source) }
+    its(:target) { is_expected.to eql String }
   end
 
   context "with multiple qualified models" do
     let(:list) { ["info:fedora/fedora-system:FedoraObject-3.0", "info:fedora/afmodel:Array", "info:fedora/afmodel:String"] }
-    subject { described_class.new(list).build }
-    it "chooses the first one that is valid" do
-      expect(subject.target).to eql Array
-    end
+    subject { described_class.new(mock_source) }
+    its(:target) { is_expected.to eql Array }
   end
 
   context "with a single qualified model" do
-    subject { described_class.new("info:fedora/afmodel:Array").build }
-    it "is valid" do
-      expect(subject.target).to eql Array
-    end
+    let(:list) { "info:fedora/afmodel:Array" }
+    subject { described_class.new(mock_source) }
+    its(:target) { is_expected.to eql Array }
   end
 
   context "with multiple unqualified models" do
     let(:list) { ["info:fedora/fedora-system:FedoraObject-3.0", "info:fedora/fedora-system:FooObject"] }
-    subject { described_class.new(list).build.target }
-    it { is_expected.to be_nil }
+    subject { described_class.new(mock_source) }
+    its(:target) { is_expected.to be_nil }
   end
 end


### PR DESCRIPTION
Updates TargetConstructor to return and instance of the target, and demonstrates how you might override it if you wanted to provide your own way of creating targets during your migration.

ping @dchandekstark @coblej RE: #49