### PR TITLE
Wrap migration source.content in StringIO for files greater than 2 GB…

### DIFF
--- a/lib/fedora_migrate/content_mover.rb
+++ b/lib/fedora_migrate/content_mover.rb
@@ -22,7 +22,7 @@ module FedoraMigrate
     end
 
     def move_content
-      target.content = source.content
+      target.content = StringIO.new(source.content)
       target.original_name = source.label.try(:gsub, /"/, '\"')
       target.mime_type = source.mimeType
       save

--- a/spec/unit/content_mover_spec.rb
+++ b/spec/unit/content_mover_spec.rb
@@ -33,7 +33,7 @@ describe FedoraMigrate::ContentMover do
 
   describe "#move_content" do
     before do
-      allow(target).to receive(:content=).with("foo")
+      allow(target).to receive(:content=)
       allow(target).to receive(:original_name=).with("label")
       allow(target).to receive(:mime_type=).with("mimetype")
       allow(target).to receive(:save).and_return(true)


### PR DESCRIPTION
…; fixes #59.