### PR TITLE
Attempt to resolve namespaced models

### DIFF
--- a/lib/fedora_migrate/target_constructor.rb
+++ b/lib/fedora_migrate/target_constructor.rb
@@ -22,9 +22,21 @@ module FedoraMigrate
       end
 
       def vet(model)
+        klass = class_from_model(model)
+        klass ||= namespaced_class_from_model(model)
+        Logger.debug "rejecting #{model} for target" if klass.nil?
+        klass
+      end
+
+      def class_from_model(model)
         FedoraMigrate::Mover.id_component(model).constantize
       rescue NameError
-        Logger.debug "rejecting #{model} for target"
+        nil
+      end
+
+      def namespaced_class_from_model(model)
+        FedoraMigrate::Mover.id_component(model).split(/_/).map(&:camelize).join('::').constantize
+      rescue NameError
         nil
       end
 

--- a/spec/unit/target_constructor_spec.rb
+++ b/spec/unit/target_constructor_spec.rb
@@ -25,4 +25,10 @@ describe FedoraMigrate::TargetConstructor do
     subject { described_class.new(mock_source) }
     its(:target) { is_expected.to be_nil }
   end
+
+  context "with a namespaced model" do
+    let(:list) { "info:fedora/afmodel:Enumerator_Lazy" }
+    subject { described_class.new(mock_source) }
+    its(:target) { is_expected.to eql Enumerator::Lazy }
+  end
 end


### PR DESCRIPTION
Avalon has a namespaced model which ActiveFedora turns into a uri with an underscore replacing the double colon.  This PR first attempts to find the model using the underscore then falls back to ActiveFedora's style of parsing of the model uri.