### PR TITLE
Add rdf-rdfxml dependency since it is no longer pulled in by rdf >= 2

### DIFF
--- a/fedora-migrate.gemspec
+++ b/fedora-migrate.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rubydora", "~> 1.8"
   spec.add_dependency "rchardet"
+  spec.add_dependency "rdf-rdfxml"
   
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "equivalent-xml"


### PR DESCRIPTION
Ruby-rdf versions 2 and greater drop the rdf-rdfxml development dependency which the RelsExtDatastreamMover depends on.  With it gone, I'm getting a NoMethodError:

*** NoMethodError Exception: undefined method `from_rdfxml' for #<RDF::Graph:0x3feacdbe7970(default)>